### PR TITLE
Some pipe2jpeg improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pipe2jpeg
+# [ARCHIVED - refer to fork parent by kevinGodell] pipe2jpeg
 ###### [![Build Status](https://travis-ci.org/kevinGodell/pipe2jpeg.svg?branch=master)](https://travis-ci.org/kevinGodell/pipe2jpeg) [![Build status](https://ci.appveyor.com/api/projects/status/jbqs74nnvc1x7v9u/branch/master?svg=true)](https://ci.appveyor.com/project/kevinGodell/pipe2jpeg/branch/master) [![GitHub issues](https://img.shields.io/github/issues/kevinGodell/pipe2jpeg.svg)](https://github.com/kevinGodell/pipe2jpeg/issues) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/kevinGodell/pipe2jpeg/master/LICENSE)
 Parse individual jpegs from an ffmpeg pipe when output codec(**-c:v**) is set to ***mjpeg*** and format(**-f**) is set to ***image2pipe***, ***singlejpeg***, ***mjpeg***, or ***mpjpeg***. All jpegs will be found regardless of size or fps. See [testing](https://www.npmjs.com/package/pipe2jpeg#testing) instructions for verification.
 ### installation:

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class Pipe2Jpeg extends Transform {
     super(options);
     this._chunks = [];
     this._size = 0;
+    this._increment = options?.increment ?? 500;
   }
 
   /**
@@ -92,8 +93,7 @@ class Pipe2Jpeg extends Transform {
         if (soi === -1) {
           break;
         } else {
-          // todo might add option or take sample average / 2 to jump position for small gain
-          pos = soi + 500;
+          pos = soi + this._increment;
         }
         const eoi = chunk.indexOf(_EOI, pos);
         if (eoi === -1) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class Pipe2Jpeg extends Transform {
     super(options);
     this._chunks = [];
     this._size = 0;
-    this._increment = options?.increment ?? 500;
+    this._increment = options?.increment ?? 250;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lumen5/pipe2jpeg",
+  "name": "lumen5-pipe2jpeg",
   "version": "0.3.1",
   "description": "Parse individual jpegs from an ffmpeg pipe when output codec is set to mjpeg and format is set to image2pipe, singlejpeg, mjpeg, or mpjeg.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lumen5-pipe2jpeg",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Parse individual jpegs from an ffmpeg pipe when output codec is set to mjpeg and format is set to image2pipe, singlejpeg, mjpeg, or mpjeg.",
   "main": "index.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lumen5-pipe2jpeg",
-  "version": "0.3.3",
+  "name": "pipe2jpeg",
+  "version": "0.3.2",
   "description": "Parse individual jpegs from an ffmpeg pipe when output codec is set to mjpeg and format is set to image2pipe, singlejpeg, mjpeg, or mpjeg.",
   "main": "index.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pipe2jpeg",
+  "name": "@lumen5/pipe2jpeg",
   "version": "0.3.1",
   "description": "Parse individual jpegs from an ffmpeg pipe when output codec is set to mjpeg and format is set to image2pipe, singlejpeg, mjpeg, or mpjeg.",
   "main": "index.js",


### PR DESCRIPTION
We've been using your library (thanks for making it!), but came across two cases we needed to improve. Thought I would push these upstream as well in case you would like to integrate it as well:

1. Smarter forward seeking when looking for end of input (EOI) after receiving the start of input (SOI). Before it was just a fixed offset, which could cause issues if the forward skip missed the next EOI. The new approach uses half of the size of the last received jpeg (so the assumption here is that the input frames won't be widely different sizes, which I think is reasonable).

2. I had an edge case where ffmpeg split the EOI across two chunks. So the last byte of the previous chunk had the first byte of EOI and the next chunk started with the second byte of EOI. I've updated the logic to handle this case, and also the related case of where the SOI could be split (but that case was not something I've come across yet).